### PR TITLE
[BOLT-TESTS] Replace cache+ option with ext-tsp

### DIFF
--- a/test/X86/clang.test
+++ b/test/X86/clang.test
@@ -9,7 +9,7 @@ RUN: test -f %p/Output/clang || unzstd %p/Inputs/clang.zst -o %p/Output/clang
 RUN: test -f %p/Output/clang.fdata || \
 RUN:    unzstd %p/Inputs/clang.fdata.zst -o %p/Output/clang.fdata
 RUN: llvm-bolt %p/Output/clang -o %t -b %p/Output/clang.fdata -profile-ignore-hash \
-RUN:    -relocs -reorder-blocks=cache+ -split-functions=3 -split-all-cold \
+RUN:    -relocs -reorder-blocks=ext-tsp -split-functions=3 -split-all-cold \
 RUN:    -split-eh -icf=1 -reorder-functions=hfsort+ -use-gnu-stack \
 RUN:    -jump-tables=move -frame-opt=hot -peepholes=all
 RUN: %t %p/Inputs/bf.cpp -O2 -std=c++11 -c -o %t.out

--- a/test/X86/clang7-pic.test
+++ b/test/X86/clang7-pic.test
@@ -9,7 +9,7 @@ RUN:    unzstd %p/Inputs/clang-7.pic.zst -o %p/Output/clang-7.pic
 RUN: test -f %p/Output/clang-7.pic.fdata || \
 RUN:    unzstd %p/Inputs/clang-7.pic.fdata.zst -o %p/Output/clang-7.pic.fdata
 RUN: llvm-bolt %p/Output/clang-7.pic -o %t -data %p/Output/clang-7.pic.fdata \
-RUN:    -relocs -reorder-blocks=cache+ -split-functions=3 -split-all-cold \
+RUN:    -relocs -reorder-blocks=ext-tsp -split-functions=3 -split-all-cold \
 RUN:    -split-eh -icf=1 -reorder-functions=hfsort+ -use-gnu-stack \
 RUN:    -jump-tables=aggressive -frame-opt=hot -strict \
 RUN:    | FileCheck %s --check-prefix=CHECK-STRICT
@@ -20,7 +20,7 @@ CHECK-STRICT: BOLT-INFO: 14724 out of 59493 functions in the binary (24.7%) have
 
 # Non-relocation mode test.
 RUN: llvm-bolt %p/Output/clang-7.pic -o %t -data %p/Output/clang-7.pic.fdata \
-RUN:    -relocs=0 -reorder-blocks=cache+ -split-functions=1 \
+RUN:    -relocs=0 -reorder-blocks=ext-tsp -split-functions=1 \
 RUN:    -use-gnu-stack -jump-tables=aggressive -frame-opt=hot \
 RUN:    | FileCheck %s
 RUN: %t %p/Inputs/clang-7.pic.input.cpp -O2 -c -o %t.out

--- a/test/X86/exceptions-pie.test
+++ b/test/X86/exceptions-pie.test
@@ -3,10 +3,10 @@
 REQUIRES: x86_64-linux
 
 RUN: llvm-bolt -relocs=0 -data %p/Inputs/exception.gcc5.pie.fdata \
-RUN:   -reorder-blocks=cache+ -split-functions=2 -split-all-cold -split-eh \
+RUN:   -reorder-blocks=ext-tsp -split-functions=2 -split-all-cold -split-eh \
 RUN:   %p/Inputs/exception.gcc5.pie -o %t && %t 2>&1 | FileCheck %s
 RUN: llvm-bolt -relocs -data %p/Inputs/exception.gcc5.pie.fdata \
-RUN:   -reorder-blocks=cache+ -reorder-functions=hfsort -split-functions=2 \
+RUN:   -reorder-blocks=ext-tsp -reorder-functions=hfsort -split-functions=2 \
 RUN:   -split-all-cold -split-eh \
 RUN:   %p/Inputs/exception.gcc5.pie -o %t && %t 2>&1 | FileCheck %s
 


### PR DESCRIPTION
ninja check-fb-bolt; grep -rnw . -e "cache+"

no more tests containing "cache+"
"cache+" and "ext-tsp" are aliases