### PR TITLE
Omit perf2bolt from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ set(BOLTTESTS_DEPS
   llvm-strip
   llvm-readelf
   not
-  perf2bolt
   )
 
 if (NOT DEFINED Python3_EXECUTABLE)


### PR DESCRIPTION
As of https://reviews.llvm.org/D151595 this symlink is always generated.