### PR TITLE
[BOLT-TESTS] Replace /dev/null with temp file

### DIFF
--- a/test/X86/perf2bolt-multiple-edge.test
+++ b/test/X86/perf2bolt-multiple-edge.test
@@ -15,17 +15,17 @@ RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.fdata -w %t.yaml
 
 # Tests for fdata vs yaml from the same perf data
 RUN: llvm-bolt -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf \
-RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o /dev/null \
+RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
 
 RUN: llvm-bolt -data %t.fdata \
-RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o /dev/null \
+RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
 
 RUN: llvm-bolt -data %t.yaml \
-RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o /dev/null \
+RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
 

--- a/test/X86/python-split-func-jtable.test
+++ b/test/X86/python-split-func-jtable.test
@@ -6,12 +6,12 @@
 # RUN: test -f %p/Output/python || \
 # RUN:   unzstd %p/Inputs/python3.8.6.zst \
 # RUN:   -o %p/Output/python
-# RUN: llvm-bolt -v=3 -instrument %p/Output/python -o /dev/null 2>&1 | \
+# RUN: llvm-bolt -v=3 -instrument %p/Output/python -o %t.null 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=CHECK-INST
 # CHECK-INST: BOLT-INFO: Multiple fragments access same jump table: sre_ucs4_match.cold/1(*2); sre_ucs4_match/1(*2)
 
 # Optimize in lite mode using pre-collected fdata profile
 #
 # RUN: llvm-bolt %p/Output/python -data %p/Inputs/python3.8.6.fdata -lite -v=1 \
-# RUN:   -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-OPT
+# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-OPT
 # CHECK-OPT: BOLT-INFO: processing pymain_init.cold/1(*2) as a sibling of non-ignored function

--- a/test/X86/split-func-icf.test
+++ b/test/X86/split-func-icf.test
@@ -7,37 +7,37 @@ CHECK-NM:      [[#%x,ADDR:]] t je_malloc_mutex_postfork_child.cold
 CHECK-NM-NEXT: [[#ADDR]]     t je_malloc_vsnprintf.cold
 
 # Ensure that BOLT doesn't crash processing the binary
-RUN: llvm-bolt %p/Inputs/merge-fdata -o /dev/null -v=1 |& FileCheck %s --check-prefix CHECK-NOSKIP
+RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null -v=1 |& FileCheck %s --check-prefix CHECK-NOSKIP
 CHECK-NOSKIP: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1
 CHECK-NOSKIP: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 CHECK-NOSKIP: BOLT-WARNING: Ignoring je_malloc_mutex_postfork_child/1
 
 # Ensure that the fragment is ignored if either parent is skipped manually
-RUN: llvm-bolt %p/Inputs/merge-fdata -o /dev/null \
+RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
 RUN:   -skip-funcs=je_malloc_vsnprintf -v=1 |& \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-PARENT1
 CHECK-SKIP-PARENT1: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 CHECK-SKIP-PARENT1: BOLT-WARNING: Ignoring je_malloc_mutex_postfork_child/1
 
-RUN: llvm-bolt %p/Inputs/merge-fdata -o /dev/null \
+RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
 RUN:   -skip-funcs=je_malloc_mutex_postfork_child -v=1 |& \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-PARENT2
 CHECK-SKIP-PARENT2: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1
 CHECK-SKIP-PARENT2: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 
-RUN: llvm-bolt %p/Inputs/merge-fdata -o /dev/null \
+RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
 RUN:   -skip-funcs=je_malloc_vsnprintf,je_malloc_mutex_postfork_child -v=1 |& \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-BOTH-PARENTS
 CHECK-SKIP-BOTH-PARENTS: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 # Ensure that the parents are ignored if the fragment is skipped manually by
 # either name
-RUN: llvm-bolt %p/Inputs/merge-fdata -o /dev/null \
+RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
 RUN:   -skip-funcs=je_malloc_vsnprintf.cold -v=1 |& \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-FRAGMENT-NAME1
 CHECK-SKIP-FRAGMENT-NAME1: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1
 CHECK-SKIP-FRAGMENT-NAME1: BOLT-WARNING: Ignoring je_malloc_mutex_postfork_child/1
 
-RUN: llvm-bolt %p/Inputs/merge-fdata -o /dev/null \
+RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
 RUN:   -skip-funcs=je_malloc_mutex_postfork_child.cold -v=1 |& \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-FRAGMENT-NAME2
 CHECK-SKIP-FRAGMENT-NAME2: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1


### PR DESCRIPTION
NFC processing time script identifies tests by output filename.
When `/dev/null` is used as output filename, we're unable to tell
the source test, and the reports are unhelpful, e.g.:
https://lab.llvm.org/buildbot/#/builders/244/builds/20918

Replace `/dev/null/ with `%t.null` which resolves the issue.

Follow-up to https://github.com/llvm/llvm-project/pull/73485
