### PR TITLE
[BOLT-TESTS] Update python tests after #89681

### DIFF
--- a/test/X86/perf2bolt-multiple-edge.test
+++ b/test/X86/perf2bolt-multiple-edge.test
@@ -11,20 +11,24 @@ RUN: test -f %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt || \
 RUN:   unzstd %p/Inputs/libpython3.8-pyston2.3.so.1.0.prebolt.zst \
 RUN:   -o %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt
 RUN: perf2bolt -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.fdata -w %t.yaml
 
 # Tests for fdata vs yaml from the same perf data
 RUN: llvm-bolt -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
 
 RUN: llvm-bolt -data %t.fdata \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
 
 RUN: llvm-bolt -data %t.yaml \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
@@ -39,6 +43,7 @@ CHECK-FUNC-NEXT: Exec Count : 10578
 
 # Test autofdo profile generation (-autofdo option)
 RUN: perf2bolt -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.afdo -autofdo
 RUN: FileCheck %s --check-prefix=CHECK-AFDO --input-file %t.afdo
 # LBR traces/fallthroughs: count, first record

--- a/test/X86/perf2bolt-multiple-edge.test
+++ b/test/X86/perf2bolt-multiple-edge.test
@@ -10,25 +10,25 @@ RUN:   -o %p/Output/libpython3.8-pyston2.3.so.1.0.perf
 RUN: test -f %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt || \
 RUN:   unzstd %p/Inputs/libpython3.8-pyston2.3.so.1.0.prebolt.zst \
 RUN:   -o %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt
-RUN: perf2bolt -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf \
+RUN: perf2bolt -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf -strict=0 \
 RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.fdata -w %t.yaml
 
 # Tests for fdata vs yaml from the same perf data
 RUN: llvm-bolt -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf \
-RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1,_PyEval_EvalFrameDefault \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
 
 RUN: llvm-bolt -data %t.fdata \
-RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1,_PyEval_EvalFrameDefault \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC
 
 RUN: llvm-bolt -data %t.yaml \
-RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
+RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1,_PyEval_EvalFrameDefault \
 RUN:   %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt -o %t.null \
 RUN:   --print-only=_PyEval_EvalCodeWithName.localalias/1,dict_dealloc --print-cfg \
 RUN:   | FileCheck %s --check-prefix=CHECK-FUNC

--- a/test/X86/python-split-func-jtable.test
+++ b/test/X86/python-split-func-jtable.test
@@ -13,5 +13,6 @@
 # Optimize in lite mode using pre-collected fdata profile
 #
 # RUN: llvm-bolt %p/Output/python -data %p/Inputs/python3.8.6.fdata -lite -v=1 \
+# RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
 # RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-OPT
 # CHECK-OPT: BOLT-INFO: processing pymain_init.cold/1(*2) as a sibling of non-ignored function

--- a/test/X86/python-split-func-jtable.test
+++ b/test/X86/python-split-func-jtable.test
@@ -6,13 +6,14 @@
 # RUN: test -f %p/Output/python || \
 # RUN:   unzstd %p/Inputs/python3.8.6.zst \
 # RUN:   -o %p/Output/python
-# RUN: llvm-bolt -v=3 -instrument %p/Output/python -o %t.null 2>&1 | \
+# RUN: llvm-bolt -v=3 -instrument %p/Output/python -o %t.null \
+# RUN:   -skip-funcs=_PyEval_EvalFrameDefault.cold/1 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=CHECK-INST
 # CHECK-INST: BOLT-INFO: Multiple fragments access same jump table: sre_ucs4_match.cold/1(*2); sre_ucs4_match/1(*2)
 
 # Optimize in lite mode using pre-collected fdata profile
 #
 # RUN: llvm-bolt %p/Output/python -data %p/Inputs/python3.8.6.fdata -lite -v=1 \
-# RUN:   -skip-funcs=_PyEval_EvalFrame_AOT_Interpreter/1 \
+# RUN:   -skip-funcs=_PyEval_EvalFrameDefault.cold/1 \
 # RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-OPT
 # CHECK-OPT: BOLT-INFO: processing pymain_init.cold/1(*2) as a sibling of non-ignored function


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/89681 added a failsafe check for rewriting certain dynamic relocations, which trigger in python test binaries. Skip the faulty functions.