### PR TITLE
Fix tests requirements

### DIFF
--- a/test/X86/openssl.test
+++ b/test/X86/openssl.test
@@ -5,7 +5,7 @@
 # - `./Configure -static -Wl,-q`
 # - profile `openssl speed` with ebpf-bolt for 100000 s
 
-REQUIRES: x86_64-linux
+REQUIRES: system-linux
 
 RUN: mkdir -p %p/Output
 RUN: test -f %p/Output/openssl || unzstd %p/Inputs/openssl.zst -o %p/Output/openssl

--- a/test/X86/python-split-func-jtable.test
+++ b/test/X86/python-split-func-jtable.test
@@ -2,6 +2,8 @@
 # The issue was triggered by getOrCreateJumpTable() when a jump table is
 # accessed from two fragments of same function.
 
+REQUIRES: x86_64-linux
+
 # RUN: mkdir -p %p/Output
 # RUN: test -f %p/Output/python || \
 # RUN:   unzstd %p/Inputs/python3.8.6.zst \


### PR DESCRIPTION
Openssl is target-independent and second one runs the x86 binary