### PR TITLE
Fix X86 heatmap test lit multithreading issue.

### DIFF
--- a/test/X86/heatmap.test
+++ b/test/X86/heatmap.test
@@ -1,11 +1,13 @@
 # Checks heatmap functionality
 RUN: mkdir -p %p/Output
 RUN: test -f %p/Output/libpython3.8-pyston2.3.so.1.0.perf || \
-RUN:   unzstd %p/Inputs/libpython3.8-pyston2.3.so.1.0.perf.zst \
-RUN:   -o %p/Output/libpython3.8-pyston2.3.so.1.0.perf
+RUN:   (unzstd %p/Inputs/libpython3.8-pyston2.3.so.1.0.perf.zst \
+RUN:     -o %t.perf && \
+RUN:    mv %t.perf %p/Output/libpython3.8-pyston2.3.so.1.0.perf)
 RUN: test -f %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt || \
-RUN:   unzstd %p/Inputs/libpython3.8-pyston2.3.so.1.0.prebolt.zst \
-RUN:   -o %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt
+RUN:   (unzstd %p/Inputs/libpython3.8-pyston2.3.so.1.0.prebolt.zst \
+RUN:     -o %t.prebolt && \
+RUN:    mv %t.prebolt %p/Output/libpython3.8-pyston2.3.so.1.0.prebolt)
 
 # Heatmap in brstack mode
 RUN: llvm-bolt-heatmap -p %p/Output/libpython3.8-pyston2.3.so.1.0.perf \


### PR DESCRIPTION
X86/heatmap.test fails on the first run when using multiple lit threads. Subsequent runs of the test do not fail.

Reproduced on an AArch64 target using BOLT's docker-tests Dockerfile.

On a single thread, there were no issues:
```bash
LIT_OPTS="-j 1" ninja check-large-bolt
```

Reproducer steps:
```bash
LIT_OPTS="-j 4" ninja check-large-bolt # expected to fail on first invocation
LIT_OPTS="-j 4" ninja check-large-bolt # expected to succeed on subsequent runs
```