### PR TITLE
Use the lit internal shell

### DIFF
--- a/lit.cfg.py
+++ b/lit.cfg.py
@@ -23,7 +23,7 @@ config.name = 'bolt-tests'
 #
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.c', '.cppm', '.m', '.mm', '.cu',

--- a/test/AArch64/bzip2-nolbr.test
+++ b/test/AArch64/bzip2-nolbr.test
@@ -9,7 +9,7 @@ RUN:   %p/Inputs/bzip2 %p/Inputs/bzip2.fdata
 
 # Convert the profile
 RUN: perf2bolt %p/Inputs/bzip2 -p %t.data -o %t.fdata -nl \
-RUN:   |& FileCheck %s -check-prefix=CHECK-P2B
+RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-P2B
 
 # Optimize using that profile
 # Check that llvm-bolt processes bzip2 binary for aarch64 in these conditions:
@@ -18,7 +18,7 @@ RUN:   |& FileCheck %s -check-prefix=CHECK-P2B
 #   - no relocs
 RUN: llvm-bolt %p/Inputs/bzip2 -o %t -lite -dyno-stats \
 RUN:   -data %t.fdata -reorder-blocks=cache -split-functions \
-RUN:   |& FileCheck %s -check-prefix=CHECK-BOLT
+RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-BOLT
 
 # Check the resulting binary
 RUN: %t %p/Inputs/bzip2.fdata

--- a/test/AArch64/bzip2.test
+++ b/test/AArch64/bzip2.test
@@ -2,7 +2,7 @@
 #   - no block reordering (just read the input and output it correctly)
 #   - no relocs
 
-RUN: llvm-bolt %p/Inputs/bzip2 -o %t |& FileCheck %s
+RUN: llvm-bolt %p/Inputs/bzip2 -o %t 2>&1 | FileCheck %s
 
 CHECK: BOLT-INFO: Target architecture: aarch64
 CHECK: BOLT: 65 out of 102 functions were overwritten.

--- a/test/X86/clang-nolbr.test
+++ b/test/X86/clang-nolbr.test
@@ -11,14 +11,14 @@ RUN:   %p/Output/clang %p/Inputs/bf.cpp -O2 -std=c++11 -c -o %t.out
 
 # Convert the profile
 RUN: perf2bolt %p/Output/clang -p %t.data -o %t.fdata -nl \
-RUN:   |& FileCheck %s -check-prefix=CHECK-P2B
+RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-P2B
 
 # Optimize using that profile
 RUN: llvm-bolt %p/Output/clang -o %t -data %t.fdata \
 RUN:    -relocs -reorder-blocks=ext-tsp -split-functions=3 -split-all-cold \
 RUN:    -split-eh -icf=1 -reorder-functions=hfsort+ -use-gnu-stack \
 RUN:    -jump-tables=move -frame-opt=hot -peepholes=all -dyno-stats \
-RUN:   |& FileCheck %s -check-prefix=CHECK-BOLT
+RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-BOLT
 
 # Check the resulting binary
 RUN: %t %p/Inputs/bf.cpp -O2 -std=c++11 -c -o %t.out

--- a/test/X86/clang.test
+++ b/test/X86/clang.test
@@ -27,7 +27,7 @@ RUN:    -icp-calls-total-percent-threshold=0 \
 RUN:    -icp-top-callsites=0 \
 RUN:    -eliminate-unreachable -peepholes=all \
 RUN:    -use-gnu-stack -dyno-stats -icp-jump-tables-targets \
-RUN:    |& FileCheck %s
+RUN:    2>&1 | FileCheck %s
 RUN: %t %p/Inputs/bf.cpp -O2 -std=c++11 -c -o %t.out
 RUN: cmp %p/Inputs/bf.o %t.out
 

--- a/test/X86/exceptions-split-strip.test
+++ b/test/X86/exceptions-split-strip.test
@@ -2,7 +2,7 @@
 
 REQUIRES: x86_64-linux
 
-RUN: llvm-bolt %p/Inputs/exception4 -use-gnu-stack -data=%p/Inputs/exception4.fdata -split-functions=1 -reorder-blocks=cache -align-blocks=1 -preserve-blocks-alignment=1 -o %t && llvm-strip %t && %t |& FileCheck %s
+RUN: llvm-bolt %p/Inputs/exception4 -use-gnu-stack -data=%p/Inputs/exception4.fdata -split-functions=1 -reorder-blocks=cache -align-blocks=1 -preserve-blocks-alignment=1 -o %t && llvm-strip %t && %t 2>&1 | FileCheck %s
 
 CHECK:      catch 2
 CHECK:      catch 1

--- a/test/X86/openssl.test
+++ b/test/X86/openssl.test
@@ -16,7 +16,7 @@ RUN:   -reorder-blocks=ext-tsp -peepholes=all -dyno-stats -enable-bat \
 RUN:   -split-functions -split-all-cold -split-eh -icf \
 RUN:   -reorder-functions=cdsort -use-gnu-stack -jump-tables=move -frame-opt=hot \
 RUN:   -print-cfg -print-only=bn_mul4x_mont.*,__memcpy_evex_unaligned_erms.*,BN_BLINDING_convert_ex \
-RUN:   |& FileCheck %s -check-prefix=CHECK-BOLT-BAT
+RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-BOLT-BAT
 
 # Check functions with multiple entries
 CHECK-BOLT-BAT: Binary Function "bn_mul4x_mont/1(*2)" after building cfg {

--- a/test/X86/split-func-icf.test
+++ b/test/X86/split-func-icf.test
@@ -7,38 +7,38 @@ CHECK-NM:      [[#%x,ADDR:]] t je_malloc_mutex_postfork_child.cold
 CHECK-NM-NEXT: [[#ADDR]]     t je_malloc_vsnprintf.cold
 
 # Ensure that BOLT doesn't crash processing the binary
-RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null -v=1 |& FileCheck %s --check-prefix CHECK-NOSKIP
+RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null -v=1 2>&1 | FileCheck %s --check-prefix CHECK-NOSKIP
 CHECK-NOSKIP: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1
 CHECK-NOSKIP: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 CHECK-NOSKIP: BOLT-WARNING: Ignoring je_malloc_mutex_postfork_child/1
 
 # Ensure that the fragment is ignored if either parent is skipped manually
 RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
-RUN:   -skip-funcs=je_malloc_vsnprintf -v=1 |& \
+RUN:   -skip-funcs=je_malloc_vsnprintf -v=1 2>&1 | \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-PARENT1
 CHECK-SKIP-PARENT1: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 CHECK-SKIP-PARENT1: BOLT-WARNING: Ignoring je_malloc_mutex_postfork_child/1
 
 RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
-RUN:   -skip-funcs=je_malloc_mutex_postfork_child -v=1 |& \
+RUN:   -skip-funcs=je_malloc_mutex_postfork_child -v=1 2>&1 | \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-PARENT2
 CHECK-SKIP-PARENT2: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1
 CHECK-SKIP-PARENT2: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 
 RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
-RUN:   -skip-funcs=je_malloc_vsnprintf,je_malloc_mutex_postfork_child -v=1 |& \
+RUN:   -skip-funcs=je_malloc_vsnprintf,je_malloc_mutex_postfork_child -v=1 2>&1 | \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-BOTH-PARENTS
 CHECK-SKIP-BOTH-PARENTS: BOLT-WARNING: Ignoring je_malloc_vsnprintf.cold/1(*4)
 # Ensure that the parents are ignored if the fragment is skipped manually by
 # either name
 RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
-RUN:   -skip-funcs=je_malloc_vsnprintf.cold -v=1 |& \
+RUN:   -skip-funcs=je_malloc_vsnprintf.cold -v=1 2>&1 | \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-FRAGMENT-NAME1
 CHECK-SKIP-FRAGMENT-NAME1: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1
 CHECK-SKIP-FRAGMENT-NAME1: BOLT-WARNING: Ignoring je_malloc_mutex_postfork_child/1
 
 RUN: llvm-bolt %p/Inputs/merge-fdata -o %t.null \
-RUN:   -skip-funcs=je_malloc_mutex_postfork_child.cold -v=1 |& \
+RUN:   -skip-funcs=je_malloc_mutex_postfork_child.cold -v=1 2>&1 | \
 RUN: FileCheck %s --check-prefix CHECK-SKIP-FRAGMENT-NAME2
 CHECK-SKIP-FRAGMENT-NAME2: BOLT-WARNING: Ignoring je_malloc_vsnprintf/1
 CHECK-SKIP-FRAGMENT-NAME2: BOLT-WARNING: Ignoring je_malloc_mutex_postfork_child/1


### PR DESCRIPTION
The external shell is deprecated and will now error out when one attempts to use it.

Also switch from |& to 2>&1 | given the internal shell does not support the former.

Fixes part of https://lab.llvm.org/buildbot/#/builders/217/builds/14154.